### PR TITLE
docs: add primary_branch to firmware update manager

### DIFF
--- a/cartographer-probe/firmware/updating-firmware.md
+++ b/cartographer-probe/firmware/updating-firmware.md
@@ -32,6 +32,7 @@ You should add both of these to your Moonraker config file to ensure that they a
 type: git_repo
 path: ~/cartographer_firmware
 origin: https://github.com/Cartographer3D/cartographer_firmware.git
+primary_branch: main
 is_system_service: False
 
 [update_manager katapult]

--- a/cartographer-probe/installation-and-setup/software-configuration/klipper-setup.md
+++ b/cartographer-probe/installation-and-setup/software-configuration/klipper-setup.md
@@ -52,6 +52,7 @@ info_tags: desc=Cartographer Plugin
 
 [update_manager Cartographer Firmware]
 type: git_repo
+primary_branch: main
 path: ~/cartographer_firmware
 is_system_service: False
 origin: https://github.com/Cartographer3D/cartographer_firmware.git


### PR DESCRIPTION
this prevents a moonraker warning about origin/master vs origin/main branch.